### PR TITLE
adding a suffix to jar name

### DIFF
--- a/job-server/src/spark.jobserver/io/JobFileDAO.scala
+++ b/job-server/src/spark.jobserver/io/JobFileDAO.scala
@@ -135,7 +135,7 @@ class JobFileDAO(config: Config) extends JobDAO {
     new File(rootDir, createJarName(appName, uploadTime) + ".jar").getAbsolutePath
 
   private def createJarName(appName: String, uploadTime: DateTime): String =
-    appName + "-" + uploadTime.toString().replace(':', '_')
+     appName + "_SNAPPY_JOB_SERVER_JAR_" + uploadTime.toString().replace(':', '_')
 
   override def saveJobInfo(jobInfo: JobInfo) {
     writeJobInfo(jobsOutputStream, jobInfo)


### PR DESCRIPTION
A suffix is added to jar name so that executors can identify that
job server  has provided the updated  jar file and the old jarLoader could be replaced with new Jar.

related PR -
https://github.com/SnappyDataInc/spark-jobserver/pull/1
https://github.com/SnappyDataInc/snappy-spark/pull/39
https://github.com/SnappyDataInc/snappy-store/pull/88
https://github.com/SnappyDataInc/snappydata/pull/310
