### PR TITLE
Fix for SNAP-1134 by properly sending error message to StatusActor in…

### DIFF
--- a/job-server/src/spark.jobserver/JobManagerActor.scala
+++ b/job-server/src/spark.jobserver/JobManagerActor.scala
@@ -325,6 +325,11 @@ class JobManagerActor(contextConfig: Config) extends InstrumentedActor {
           throw e
         }
         case NonFatal(e) => {
+          /**
+           *  Handling for Non-Fatal error was done separatly due to this scala issue(
+           *  https://issues.scala-lang.org/browse/SI-8938) which causes the Future to not
+           *  properly returning the status so wrapping the Fatal error in the following case
+           */
           logger.error("Got NonFatal Exception: ", e)
           throw e
         };

--- a/job-server/src/spark.jobserver/JobManagerActor.scala
+++ b/job-server/src/spark.jobserver/JobManagerActor.scala
@@ -5,6 +5,8 @@ package spark.jobserver
 
 import java.util.concurrent.Executors._
 
+import scala.util.control.NonFatal
+
 import akka.actor.{ActorRef, PoisonPill, Props}
 import com.typesafe.config.Config
 import java.net.{URI, URL}
@@ -320,14 +322,16 @@ class JobManagerActor(contextConfig: Config) extends InstrumentedActor {
         case e: java.lang.AbstractMethodError => {
           logger.error("Oops, there's an AbstractMethodError... maybe you compiled " +
             "your code with an older version of SJS? here's the exception:", e)
-          statusActor ! JobErroredOut(jobId, DateTime.now(), e)
           throw e
         }
-        case e: Throwable => {
-          logger.error("Got Throwable", e)
-          statusActor ! JobErroredOut(jobId, DateTime.now(), e)
+        case NonFatal(e) => {
+          logger.error("Got NonFatal Exception: ", e)
           throw e
         };
+        case e : Throwable => {
+          logger.error("Got Fatal Exception: ", e)
+          throw wrapInRuntimeException(e)
+        }
       }
     }(executionContext).andThen {
       case Success(result: Any) =>
@@ -342,6 +346,9 @@ class JobManagerActor(contextConfig: Config) extends InstrumentedActor {
         // Either way an enhancement would be required here to make Stream[_] responses work
         // with context-per-jvm=true configuration
         resultActor ! JobResult(jobId, result)
+      case Failure(error: RuntimeException) =>
+        statusActor ! JobErroredOut(jobId, DateTime.now(), error)
+        logger.error("Exception from job " + jobId + ": ", error)
       case Failure(error: Throwable) =>
         // Wrapping the error inside a RuntimeException to handle the case of throwing custom exceptions.
         val wrappedError = wrapInRuntimeException(error)

--- a/job-server/src/spark.jobserver/JobManagerActor.scala
+++ b/job-server/src/spark.jobserver/JobManagerActor.scala
@@ -320,10 +320,12 @@ class JobManagerActor(contextConfig: Config) extends InstrumentedActor {
         case e: java.lang.AbstractMethodError => {
           logger.error("Oops, there's an AbstractMethodError... maybe you compiled " +
             "your code with an older version of SJS? here's the exception:", e)
+          statusActor ! JobErroredOut(jobId, DateTime.now(), e)
           throw e
         }
         case e: Throwable => {
           logger.error("Got Throwable", e)
+          statusActor ! JobErroredOut(jobId, DateTime.now(), e)
           throw e
         };
       }


### PR DESCRIPTION
## Changes proposed in this pull request
* The job was getting stuck in running state in case of failure because Job error message was not getting send to the StatusActor.Sending proper JobErroredOut message has fixed this issue

## Patch testing
* Tested Manually

## Other PRs 
N/A

… case of failure in snappy job