### PR TITLE
SNAP-1351

### DIFF
--- a/job-server/src/spark.jobserver/JobManagerActor.scala
+++ b/job-server/src/spark.jobserver/JobManagerActor.scala
@@ -311,7 +311,8 @@ class JobManagerActor(contextConfig: Config) extends InstrumentedActor {
             case SparkJobValid => {
               statusActor ! JobStarted(jobId: String, contextName, jobInfo.startTime)
               val sc = jobContext.sparkContext
-              sc.setJobGroup(jobId, s"Job group for $jobId and spark context ${sc.applicationId}", true)
+              sc.setJobGroup(jobId, s"Job group for $jobId " +
+                  s"and spark context ${sc.applicationId}", false)
               job.runJob(jobC, jobConfig)
             }
           }

--- a/job-server/src/spark.jobserver/JobManagerActor.scala
+++ b/job-server/src/spark.jobserver/JobManagerActor.scala
@@ -311,8 +311,11 @@ class JobManagerActor(contextConfig: Config) extends InstrumentedActor {
             case SparkJobValid => {
               statusActor ! JobStarted(jobId: String, contextName, jobInfo.startTime)
               val sc = jobContext.sparkContext
+              // When tasks are killed, the task threads cannot be interrupted
+              // as it can create issues if the thread is writing on disk etc.
+              // So setting interrupt as false.
               sc.setJobGroup(jobId, s"Job group for $jobId " +
-                  s"and spark context ${sc.applicationId}", false)
+                  s"and spark context ${sc.applicationId}", interruptOnCancel = false)
               job.runJob(jobC, jobConfig)
             }
           }


### PR DESCRIPTION
# Changes proposed in this pull request

When starting a job, a property is set which decides whether to interrupt task threads if the job/tasks are killed. This property is set as true by job server. During a failure, when tasks are killed by the driver, it sends executors a message to interrupt the task threads. This causes issues with snappy because snappy may be writing to an oplog and it generates a DiskAccessException. This DAE ends up closing the underlying regions.

Snappy threads cannot be interrupted and hence making this flag as false.

## Patch testing

Tried out the scenario mentioned in the bug. Works fine. Precheckin. 

## Other PRs 
https://github.com/SnappyDataInc/snappydata/pull/581

