### PR TITLE
Snap 1344

### DIFF
--- a/job-server-api/src/spark.jobserver/ContextLike.scala
+++ b/job-server-api/src/spark.jobserver/ContextLike.scala
@@ -36,4 +36,8 @@ trait ContextLike {
   def makeClassLoader(parent : ContextURLClassLoader): ContextURLClassLoader ={
     new ContextURLClassLoader(parent.getURLs, parent)
   }
+
+  def addJobJar(jarName : String) = {
+    // do nothing for not required cases like HiveContextFactory
+  }
 }


### PR DESCRIPTION
 As streaming jobs are recurring jobs, the earlier mechanism of removing dependent jar files were broken.
This change will ensure we maintain a list of jars in the context itself and will remove the jars when the streaming context is stopped.
When streaming context is stopped we can safely remove those jars.