### PR TITLE
Merge Branch jj 0.6.2.4 into Master

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@
 
 apply plugin: 'scala'
 
-version = '0.6.3-3'
+version = '0.6.2.3'
 
 ext {
   nettyGroup = 'io.netty'

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@
 
 apply plugin: 'scala'
 
-version = '0.6.3-2'
+version = '0.6.3-3'
 
 ext {
   nettyGroup = 'io.netty'

--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,15 @@ dependencies {
   // always use stock spark so that snappy extensions don't get accidently
   // included here in jobserver code.
   provided("org.apache.spark:spark-core_${scalaBinaryVersion}:${sparkVersion}") {
+    exclude(group: 'org.apache.spark', module: "spark-unsafe_${scalaBinaryVersion}")
+    exclude(group: nettyGroup)
+    exclude(group: scalaMacros)
+    exclude(group: 'org.scala-lang', module: 'scala-library')
+    exclude(group: 'org.scala-lang', module: 'scala-reflect')
+    exclude(group: 'org.scala-lang', module: 'scala-compiler')
+  }
+  provided("org.apache.spark:spark-catalyst_${scalaBinaryVersion}:${sparkVersion}") {
+    exclude(group: 'org.apache.spark', module: "spark-unsafe_${scalaBinaryVersion}")
     exclude(group: nettyGroup)
     exclude(group: scalaMacros)
     exclude(group: 'org.scala-lang', module: 'scala-library')
@@ -66,6 +75,7 @@ dependencies {
     exclude(group: 'org.scala-lang', module: 'scala-compiler')
   }
   provided("org.apache.spark:spark-sql_${scalaBinaryVersion}:${sparkVersion}") {
+    exclude(group: 'org.apache.spark', module: "spark-unsafe_${scalaBinaryVersion}")
     exclude(group: nettyGroup)
     exclude(group: scalaMacros)
     exclude(group: 'org.scala-lang', module: 'scala-library')
@@ -73,6 +83,7 @@ dependencies {
     exclude(group: 'org.scala-lang', module: 'scala-compiler')
   }
   provided("org.apache.spark:spark-mllib_${scalaBinaryVersion}:${sparkVersion}") {
+    exclude(group: 'org.apache.spark', module: "spark-unsafe_${scalaBinaryVersion}")
     exclude(group: nettyGroup)
     exclude(group: scalaMacros)
     exclude(group: 'org.scala-lang', module: 'scala-library')
@@ -80,6 +91,7 @@ dependencies {
     exclude(group: 'org.scala-lang', module: 'scala-compiler')
   }
   provided("org.apache.spark:spark-streaming_${scalaBinaryVersion}:${sparkVersion}") {
+    exclude(group: 'org.apache.spark', module: "spark-unsafe_${scalaBinaryVersion}")
     exclude(group: nettyGroup)
     exclude(group: scalaMacros)
     exclude(group: 'org.scala-lang', module: 'scala-library')
@@ -87,6 +99,7 @@ dependencies {
     exclude(group: 'org.scala-lang', module: 'scala-compiler')
   }
   provided("org.apache.spark:spark-hive_${scalaBinaryVersion}:${sparkVersion}") {
+    exclude(group: 'org.apache.spark', module: "spark-unsafe_${scalaBinaryVersion}")
     exclude(group: nettyGroup)
     exclude(group: scalaMacros)
     exclude(group: scalaTest)


### PR DESCRIPTION
# Changes proposed in this pull request

- Bump up the versions Store 1.5.4, Spark 2.0.3-3 and Jobserver 0.6.3-3
- Change to a new version naming policy.
- [SNAPPYDATA] explicitly exclude spark-unsafe

# Patch testing
- Pre-checkin yet to be run

# Other PRs

- SnappyData : https://github.com/SnappyDataInc/snappydata/pull/598
- Spark : https://github.com/SnappyDataInc/spark/pull/49
- Store: https://github.com/SnappyDataInc/snappy-store/pull/185
- AQP: https://github.com/SnappyDataInc/snappy-aqp/pull/146