### PR TITLE
Snap 1520

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,6 @@ dependencies {
   // always use stock spark so that snappy extensions don't get accidently
   // included here in jobserver code.
   provided("org.apache.spark:spark-core_${scalaBinaryVersion}:${sparkVersion}") {
-    exclude(group: 'org.apache.spark', module: "spark-unsafe_${scalaBinaryVersion}")
     exclude(group: nettyGroup)
     exclude(group: scalaMacros)
     exclude(group: 'org.scala-lang', module: 'scala-library')
@@ -67,7 +66,6 @@ dependencies {
     exclude(group: 'org.scala-lang', module: 'scala-compiler')
   }
   provided("org.apache.spark:spark-catalyst_${scalaBinaryVersion}:${sparkVersion}") {
-    exclude(group: 'org.apache.spark', module: "spark-unsafe_${scalaBinaryVersion}")
     exclude(group: nettyGroup)
     exclude(group: scalaMacros)
     exclude(group: 'org.scala-lang', module: 'scala-library')
@@ -75,7 +73,6 @@ dependencies {
     exclude(group: 'org.scala-lang', module: 'scala-compiler')
   }
   provided("org.apache.spark:spark-sql_${scalaBinaryVersion}:${sparkVersion}") {
-    exclude(group: 'org.apache.spark', module: "spark-unsafe_${scalaBinaryVersion}")
     exclude(group: nettyGroup)
     exclude(group: scalaMacros)
     exclude(group: 'org.scala-lang', module: 'scala-library')
@@ -83,7 +80,6 @@ dependencies {
     exclude(group: 'org.scala-lang', module: 'scala-compiler')
   }
   provided("org.apache.spark:spark-mllib_${scalaBinaryVersion}:${sparkVersion}") {
-    exclude(group: 'org.apache.spark', module: "spark-unsafe_${scalaBinaryVersion}")
     exclude(group: nettyGroup)
     exclude(group: scalaMacros)
     exclude(group: 'org.scala-lang', module: 'scala-library')
@@ -91,7 +87,6 @@ dependencies {
     exclude(group: 'org.scala-lang', module: 'scala-compiler')
   }
   provided("org.apache.spark:spark-streaming_${scalaBinaryVersion}:${sparkVersion}") {
-    exclude(group: 'org.apache.spark', module: "spark-unsafe_${scalaBinaryVersion}")
     exclude(group: nettyGroup)
     exclude(group: scalaMacros)
     exclude(group: 'org.scala-lang', module: 'scala-library')
@@ -99,7 +94,6 @@ dependencies {
     exclude(group: 'org.scala-lang', module: 'scala-compiler')
   }
   provided("org.apache.spark:spark-hive_${scalaBinaryVersion}:${sparkVersion}") {
-    exclude(group: 'org.apache.spark', module: "spark-unsafe_${scalaBinaryVersion}")
     exclude(group: nettyGroup)
     exclude(group: scalaMacros)
     exclude(group: scalaTest)


### PR DESCRIPTION
**Changes proposed in this pull request**
Relocate on unsafe packages causes issues to end-user when writing application on Snappy.

Proposed changes have take these measures as suggested by Sumedh.
a) change snappy-spark-unsafe references in store build.gradles to upstream spark 2.0.0 unsafe; likewise remove from core/build.gradle and remove relocations of that everywhere

b) remove explicit KryoSerializableSerializer registration for UnsafeRow and UTF8String in PooledKryoSerializer and instead call just the .register() method which will determine the serializer to be used by reflection

**Patch testing**
Manual testing
Precheckin

**ReleaseNotes changes**
No

**Other PRs**
SnappyDataInc/snappydata#612