### PR TITLE
SNAP-1841 Replace the default authenticator (no-op) of jobserver with a simple one for snappydata.

### DIFF
--- a/job-server/src/spark.jobserver/auth/User.scala
+++ b/job-server/src/spark.jobserver/auth/User.scala
@@ -4,4 +4,4 @@ package spark.jobserver.auth
  * minimal user info, for more advanced permission checking, it might be necessary
  * to add more properties such as group memberships
  */
-case class User(login: String)
+case class User(login: String, token: String = "")


### PR DESCRIPTION
* Replace the default authenticator (no-op) of jobserver with a simple one for snappydata.
* This simple authenticator again is replaced to invoke snappy's authentication API when cluster is
  started in secure mode.

Manually tested.

Other PRs:
https://github.com/SnappyDataInc/snappydata/pull/737
https://github.com/SnappyDataInc/snappy-store/pull/252