### PR TITLE
[SNAP-2306] Added code to call stop.

### DIFF
--- a/job-server/src/spark.jobserver/JobManagerActor.scala
+++ b/job-server/src/spark.jobserver/JobManagerActor.scala
@@ -168,6 +168,9 @@ class JobManagerActor(contextConfig: Config) extends InstrumentedActor {
 
     case KillJob(jobId: String) => {
       jobContext.sparkContext.cancelJobGroup(jobId)
+      // This is assuming we always will use new SnappySQLJob,
+      // both for adhoc and streaming jobs.
+      jobContext.stop
       statusActor ! JobKilled(jobId, DateTime.now())
     }
 


### PR DESCRIPTION
Adde code to call ContextLike.stop method in job kill code path. This will ensure calling clean-up operations which can be added to ContextLike implementation. 