### PR TITLE
[SNAP-2909] - Stopping the active streaming queries once the snappy-job is completed

### DIFF
--- a/job-server/src/spark.jobserver/JobManagerActor.scala
+++ b/job-server/src/spark.jobserver/JobManagerActor.scala
@@ -337,6 +337,7 @@ class JobManagerActor(contextConfig: Config) extends InstrumentedActor {
             }
           }
         } finally {
+          jobContext.stop()
           org.slf4j.MDC.remove("jobId")
         }
       } catch {


### PR DESCRIPTION
**Changes proposed:**

Stopping the active streaming queries once the snappy-job is completed

**Current behavior :** 
When snappy job fails due to failure outside the streaming query, the streaming queries started by the job keeps on running forever.

**New behavior :**
After successful or failed completion of the snappy job, we are stopping all the active streaming queries.
